### PR TITLE
Require Josepy 2.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
     { name = "Aarni Koskela", email = "akx@iki.fi" },
 ]
 dependencies = [
-    "josepy>=1.2.0",
+    "josepy>=2.0.0",
     "requests",
 ]
 


### PR DESCRIPTION
Josepy 2.0 removes PyOpenSSL altogether: https://github.com/certbot/josepy/pull/212